### PR TITLE
chore: adds dct:type to information models

### DIFF
--- a/src/fdk_model_publisher/service/mapper.py
+++ b/src/fdk_model_publisher/service/mapper.py
@@ -6,12 +6,16 @@ from datacatalogtordf import Agent, Catalog
 from fdk_rdf_parser.classes import Publisher
 from fdk_rdf_parser.fdk_rdf_parser import DataService
 from modelldcatnotordf.modelldcatno import InformationModel
+from rdflib import Namespace
 
 from fdk_model_publisher.api.models import PartialInformationModel
 from fdk_model_publisher.config import Config
 from fdk_model_publisher.mapper.ModelElementMapper import ModelElementMapper
 
+
 model_element_mapper = ModelElementMapper()
+
+MODELLDCATNO = Namespace("https://data.norge.no/vocabulary/modelldcatno#")
 
 prepend_map = {
     "nb": "Informasjonsmodell",
@@ -82,5 +86,6 @@ def map_model_from_dict(
         if data_service.conformsTo
         else None
     )
+    model.dct_type = "https://data.norge.no/vocabulary/modelldcatno#physicalModel"
 
     return model

--- a/tests/mocks/examples_ttl.py
+++ b/tests/mocks/examples_ttl.py
@@ -8,6 +8,7 @@ ex_1_ttl = """
 
 <http://uri.com> a ns1:InformationModel ;
     dct:title "Informasjonsmodell - datatjeneste eksempler"@nb ;
+    dct:type ns1:physicalModel ;
     ns1:containsModelElement <http://uri.com#Eiendom> .
 
 <http://uri.com#Eiendom> a ns1:ObjectType ;
@@ -60,6 +61,7 @@ ex_2_ttl = """
 
 <http://uri.com> a ns1:InformationModel ;
     dct:title "Informasjonsmodell - datatjeneste eksempler"@nb ;
+    dct:type ns1:physicalModel ;
     ns1:containsModelElement <http://uri.com#Eiendom>,
         <http://uri.com#EiendomResultat> .
 
@@ -141,6 +143,7 @@ ex_3_ttl = """
 
 <http://uri.com> a ns1:InformationModel ;
     dct:title "Informasjonsmodell - datatjeneste eksempler"@nb ;
+    dct:type ns1:physicalModel ;
     ns1:containsModelElement <http://uri.com#Eiendom>,
         <http://uri.com#Kommune>,
         <http://uri.com#SÃ¸k> .
@@ -261,6 +264,7 @@ ex_4_ttl = """
 
 <http://uri.com> a ns1:InformationModel ;
     dct:title "Informasjonsmodell - datatjeneste eksempler"@nb ;
+    dct:type ns1:physicalModel ;
     ns1:containsModelElement <http://uri.com#Eiendom>,
         <http://uri.com#EiendomResultat>,
         <http://uri.com#Kommune>,
@@ -468,6 +472,7 @@ ex_5_ttl = """
 
 <http://uri.com> a ns1:InformationModel ;
     dct:title "Informasjonsmodell - datatjeneste eksempler"@nb ;
+    dct:type ns1:physicalModel ;
     ns1:containsModelElement <http://uri.com#Account>,
         <http://uri.com#AccountStatus>,
         <http://uri.com#FinancialInstitution> .
@@ -516,6 +521,7 @@ ex_6_ttl = """
 
 <http://uri.com> a ns1:InformationModel ;
     dct:title "Informasjonsmodell - datatjeneste eksempler"@nb ;
+    dct:type ns1:physicalModel ;
     ns1:containsModelElement <http://uri.com#ObjA>,
         <http://uri.com#ObjC>,
         <http://uri.com#ObjD> .
@@ -573,6 +579,7 @@ ex_7_ttl = """
 
 <http://uri.com> a ns1:InformationModel ;
     dct:title "Informasjonsmodell - datatjeneste eksempler"@nb ;
+    dct:type ns1:physicalModel ;
     ns1:containsModelElement <http://uri.com#Balance>,
         <http://uri.com#BalanceType> .
 
@@ -599,6 +606,7 @@ ex_8_ttl = """
 
 <http://uri.com> a ns1:InformationModel ;
     dct:title "Informasjonsmodell - datatjeneste eksempler"@nb ;
+    dct:type ns1:physicalModel ;
     ns1:containsModelElement <http://uri.com#CounterParty>,
         <http://uri.com#Transaction>,
         <http://uri.com#TransactionReference> .

--- a/tests/mocks/skagerrak_sparebank_ttl.py
+++ b/tests/mocks/skagerrak_sparebank_ttl.py
@@ -17,6 +17,7 @@ skagerrak_sparebank_ttl_mock = """@prefix dcat: <http://www.w3.org/ns/dcat#> .
     dct:description "Open API specification of the Account APIs. (Work in progress.)"@en ;
     dct:publisher <https://fdk-model-publisher.fellesdatakatalog.no#937891245> ;
     dct:title "Information Model - Accounts API Skagerrak Sparebank"@en ;
+    dct:type ns1:physicalModel ;
     ns1:containsModelElement <https://mockurl.com/Skagerrak_Sparebank_937891245_Accounts-API.json#AccountDetails>,
         <https://mockurl.com/Skagerrak_Sparebank_937891245_Accounts-API.json#Accounts>,
         <https://mockurl.com/Skagerrak_Sparebank_937891245_Accounts-API.json#Cards>,


### PR DESCRIPTION
closes #Informasjonsforvaltning/fdk-issue-tracker/issues/242